### PR TITLE
fix user.allMessageRead method

### DIFF
--- a/lib/User.js
+++ b/lib/User.js
@@ -177,11 +177,12 @@ class User extends Sendbird {
         action: Make all messages as read
         method: PUT
         params: {
-            user_id: string
+            user_id: string,
+            channel_urls: string[]
         }
     */
     async allMessageRead(params) {
-        let req = this._makeParams('PUT', 'allMessageRead', params.user_id);
+        let req = this._makeParams('PUT', 'allMessageRead', params.user_id, params);
         return await this._request(req);
     }
 


### PR DESCRIPTION
## Changes
- I fixed an issue where an error occurs when calling the [SendbirdAPI](https://sendbird.com/docs/chat/platform-api/v3/user/marking-messages-as-read/mark-all-of-a-users-messages-as-read#2-http-request) without entering params.
  **The following error occurs:**

  ```json
  {
    "error": true,
    "data": null,
    "message": { "code": 400403, "msg": "Invalid value: \"JSON body.\"." }
  }
  ```
- add channel_urls parameters